### PR TITLE
Tito 5

### DIFF
--- a/core/settings/__init__.py
+++ b/core/settings/__init__.py
@@ -42,12 +42,14 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sites',
     'ledger.apps.LedgerConfig',
     'products.apps.ProductsConfig',
     'integration.apps.IntegrationConfig',
     "django_extensions",
     'user.apps.UserConfig',
-    'rest_framework'
+    'rest_framework',
+    'django_cas_ng',
 ]
 
 MIDDLEWARE = [
@@ -56,10 +58,24 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django_cas_ng.middleware.CASMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
 ]
+
+# Authentication
+AUTHENTICATION_BACKENDS = (
+    'django.contrib.auth.backends.ModelBackend',
+    'django_cas_ng.backends.CASBackend',
+)
+
+# CAS
+CAS_SERVER_URL = "https://account.monumetric.com/"
+CAS_LOGOUT_COMPLETELY = True
+CAS_PROVIDE_URL_TO_LOGOUT = True
+CAS_LOGIN_MSG = None
+
 
 ROOT_URLCONF = 'core.urls'
 

--- a/core/settings/__init__.py
+++ b/core/settings/__init__.py
@@ -71,7 +71,7 @@ AUTHENTICATION_BACKENDS = (
 )
 
 # CAS
-CAS_SERVER_URL = "https://account.monumetric.com/"
+CAS_SERVER_URL = os.environ.get("CAS_URL", "https://account.monumetric.com/")
 CAS_LOGOUT_COMPLETELY = True
 CAS_PROVIDE_URL_TO_LOGOUT = True
 CAS_LOGIN_MSG = None

--- a/core/urls.py
+++ b/core/urls.py
@@ -15,8 +15,11 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+import django_cas_ng.views
 
 urlpatterns = [
+    path('account/login/', django_cas_ng.views.LoginView.as_view(), name='cas_ng_login'),
+    path('account/logout/', django_cas_ng.views.LogoutView.as_view(), name='cas_ng_logout'),
     path('admin/', admin.site.urls),
     # path('slack/', include('django_slack_oauth.urls')),
     path('integration/', include('integration.urls')),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 asgiref==3.5.2
 dj-database-url==0.5.0
 Django==4.0.5
+django-cas-ng==4.3.0
 django-extensions==3.1.5
 djangorestframework==3.13.1
 Pillow==9.1.1


### PR DESCRIPTION
Added CAS connections, so users can access application using account.monumetric.com as the default authentication provider.

Eventually, we'll want to abstract this out such that the end users can use whatever CAS server they want, but that in theory should be as simple as changing the URL, but there's probably a better way to do that once we package this up as an installable application. For now, this will work fine. :)

One thing to note is that in order for the url redirects to work, we need to configure a "Site" object in the DB for each server this runs on. This can be done in the admin panel after the application boots. As part of the merge, I'll ensure staging and production are set up properly.