### PR TITLE
Updates to add API support via DRF, also add suport for OpenAPI3.1 via drf-spectacular, and add swagger and redoc UI support

### DIFF
--- a/core/settings/__init__.py
+++ b/core/settings/__init__.py
@@ -99,6 +99,15 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'core.wsgi.application'
 
+REST_FRAMEWORK = {
+    'DEFAULT_RENDERER_CLASSES': [
+        'rest_framework.renderers.TemplateHTMLRenderer',
+    ],
+    'DEFAULT_PARSER_CLASSES': [
+        'rest_framework.parsers.JSONParser',
+    ]
+}
+
 
 # Database
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases

--- a/core/settings/__init__.py
+++ b/core/settings/__init__.py
@@ -43,6 +43,8 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.sites',
+    'drf_spectacular',
+    'drf_spectacular_sidecar',
     'ledger.apps.LedgerConfig',
     'products.apps.ProductsConfig',
     'integration.apps.IntegrationConfig',
@@ -63,6 +65,17 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
 ]
+
+SPECTACULAR_SETTINGS = {
+    'SWAGGER_UI_DIST': 'SIDECAR',  # shorthand to use the sidecar instead
+    'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',
+    'REDOC_DIST': 'SIDECAR',
+    'OAS_VERSION': '3.1.0',
+    'TITLE': 'Titos Tacos Client',
+    'DESCRIPTION': 'Communicate with the taco shop API'
+    # 'COMPONENT_SPLIT_REQUEST': True,
+    # OTHER SETTINGS
+}
 
 # Authentication
 AUTHENTICATION_BACKENDS = (
@@ -100,6 +113,7 @@ TEMPLATES = [
 WSGI_APPLICATION = 'core.wsgi.application'
 
 REST_FRAMEWORK = {
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     'DEFAULT_RENDERER_CLASSES': [
         'rest_framework.renderers.TemplateHTMLRenderer',
     ],

--- a/core/urls.py
+++ b/core/urls.py
@@ -16,11 +16,17 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 import django_cas_ng.views
+from rest_framework.routers import DefaultRouter
 from . import views
-from user.views import UserViewset
+from user.views import MEView
+from products.views import ProductViewset
+from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
+
+api_router = DefaultRouter()
+api_router.register(r'products', ProductViewset, basename='products')
 
 urlpatterns = [
-    path('user/me/', UserViewset.as_view({'get': 'retrieve'}), name='me'),
+    path('user/me/', MEView.as_view(), name='me'),
     path('account/login/', django_cas_ng.views.LoginView.as_view(), name='cas_ng_login'),
     path('account/logout/', django_cas_ng.views.LogoutView.as_view(), name='cas_ng_logout'),
     path('admin/', admin.site.urls),
@@ -28,4 +34,10 @@ urlpatterns = [
     path('integration/', include('integration.urls')),
     path('', views.index, name='home-page'),
     path('products/', include('products.urls')),
+    path('api/v1/', include(api_router.urls)),
+
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    # Optional UI:
+    path('api/schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('api/schema/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 ]

--- a/core/urls.py
+++ b/core/urls.py
@@ -17,8 +17,10 @@ from django.contrib import admin
 from django.urls import path, include
 import django_cas_ng.views
 from . import views
+from user.views import UserViewset
 
 urlpatterns = [
+    path('user/me/', UserViewset.as_view({'get': 'retrieve'}), name='me'),
     path('account/login/', django_cas_ng.views.LoginView.as_view(), name='cas_ng_login'),
     path('account/logout/', django_cas_ng.views.LogoutView.as_view(), name='cas_ng_logout'),
     path('admin/', admin.site.urls),

--- a/products/serializers.py
+++ b/products/serializers.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+from products.models import Product
+
+
+class ProductSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Product
+        fields = '__all__'

--- a/products/urls.py
+++ b/products/urls.py
@@ -1,8 +1,14 @@
 from products import views
 from django.urls import path
 
+from rest_framework import routers
+router = routers.SimpleRouter()
+router.register(r'',  views.ProductViewset)
 
+urlpatterns = router.urls
 urlpatterns = [
+    path('', views.ProductViewset.as_view({'get': 'list'})),
+    path('<int:pk>/', views.ProductViewset.as_view({'get': 'retrieve'})),
     path('<int:product_id>/', views.product, name='product-page'),
     path('<int:product_id>/product_images/<str:filename>', views.get_image, name='product-img'),
     path('checkout/<int:product_id>/', views.checkout, name='checkout-page'),

--- a/products/views.py
+++ b/products/views.py
@@ -21,6 +21,7 @@ class ProductViewset(viewsets.ModelViewSet):
     serializer_class = ProductSerializer
     queryset = Product.objects.all()
 
+
 def product(request, product_id):
     product = Product.objects.filter(id=product_id).first()
     size_stock = product.attribute_stock.filter(attribute__attribute_base__name = 'Size', stock__gte = 1)

--- a/products/views.py
+++ b/products/views.py
@@ -10,6 +10,16 @@ from django.conf import settings
 from django.contrib import messages
 from .forms import ProductSizeForm
 
+from rest_framework import viewsets
+from rest_framework.renderers import JSONRenderer, TemplateHTMLRenderer
+from products.serializers import ProductSerializer
+
+
+class ProductViewset(viewsets.ModelViewSet):
+
+    renderer_classes = [JSONRenderer]
+    serializer_class = ProductSerializer
+    queryset = Product.objects.all()
 
 def product(request, product_id):
     product = Product.objects.filter(id=product_id).first()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ django-cas-ng==4.3.0
 django-extensions==3.1.5
 djangorestframework==3.13.1
 django-storages==1.13.2
+drf-spectacular==0.27.2
 google-api-core==2.11.0
 google-api-python-client==2.105.0
 google-auth==2.16.2

--- a/user/serializers.py
+++ b/user/serializers.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+from user.models import User
+
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = '__all__'

--- a/user/serializers.py
+++ b/user/serializers.py
@@ -1,8 +1,16 @@
 from rest_framework import serializers
 from user.models import User
+from ledger.models import TacoBank
 
 
 class UserSerializer(serializers.ModelSerializer):
+
+    taco_balance = serializers.SerializerMethodField()
+
+    @classmethod
+    def get_taco_balance(csl, user) -> int:
+        return TacoBank.objects.get_or_create(user=user)[0].total_tacos if user.is_authenticated else 0
+
     class Meta:
         model = User
-        fields = '__all__'
+        fields = ('first_name', 'last_name', 'email', 'unique_id', 'taco_balance')

--- a/user/views.py
+++ b/user/views.py
@@ -1,3 +1,13 @@
 from django.shortcuts import render
+from rest_framework import viewsets
+from user.models import User
+from user.serializers import UserSerializer
 
-# Create your views here.
+class UserViewset(viewsets.ModelViewSet):
+
+    serializer_class = UserSerializer
+    
+    def get_queryset(self):
+        print("USER GET QUERYSET")
+        return super().get_queryset().filter(id=self.request.user.id)
+

--- a/user/views.py
+++ b/user/views.py
@@ -2,12 +2,19 @@ from django.shortcuts import render
 from rest_framework import viewsets
 from user.models import User
 from user.serializers import UserSerializer
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework.renderers import JSONRenderer
 
-class UserViewset(viewsets.ModelViewSet):
 
+class MEView(APIView):
+    renderer_classes = [JSONRenderer]
     serializer_class = UserSerializer
-    
-    def get_queryset(self):
-        print("USER GET QUERYSET")
-        return super().get_queryset().filter(id=self.request.user.id)
 
+    def get(self, request):
+        """
+        Return user details
+        """
+        serializer = UserSerializer(request.user)
+        return Response(serializer.data)


### PR DESCRIPTION
This PR looks a bit bigger than it actually is. :D Most of it is configuration.

This adds support for django rest framework, and exposes an api over /api/v1. In said API, there are just two products currently handled- User information via /user/me, and products.

Lastly, I added openapi3 support via drf-spectacular, and enabled the sidecar so that both the swagger and redoc Documentation UIs are available under `api/schema/` This one currently isn't versioned, but it could be pretty quick if we need documentation for specific api versions.